### PR TITLE
fix the reorder warnings of the Lowwi wakeword class and the example …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ else()
         target_link_libraries(${PROJECT_NAME} onnxruntime onnxruntime_providers_shared)
 
         # Turn off some compile warnings which are windows specific (but not fixable, due to it being an ONNX problem)
-        target_compile_options(${PROJECT_NAME} PRIVATE /wd4820  # Suppresses warning C4820
+        target_compile_options(${PROJECT_NAME} PUBLIC  /wd4820  # Suppresses warning C4820
                                                        /wd4514  # Suppresses warning C4514
                                                        /wd4710  # Suppresses warning C4710
                                                        /Qspectre # Enable spectre vulnerability mitigations

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ else()
         target_compile_options(${PROJECT_NAME} PRIVATE /wd4820  # Suppresses warning C4820
                                                        /wd4514  # Suppresses warning C4514
                                                        /wd4710  # Suppresses warning C4710
-                                                       /wd4626  # Suppresses warning C4625
                                                        /Qspectre # Enable spectre vulnerability mitigations
                                                        )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,13 @@ else()
         target_link_libraries(${PROJECT_NAME} onnxruntime onnxruntime_providers_shared)
 
         # Turn off some compile warnings which are windows specific (but not fixable, due to it being an ONNX problem)
-        target_compile_options(${PROJECT_NAME} PUBLIC  /wd4820  # Suppresses warning C4820
-                                                       /wd4514  # Suppresses warning C4514
-                                                       /wd4710  # Suppresses warning C4710
-                                                       /Qspectre # Enable spectre vulnerability mitigations
+        target_compile_options(${PROJECT_NAME} PRIVATE  /wd4820  # Suppresses warning C4820
+                                                        /wd4514  # Suppresses warning C4514
+                                                        /wd4710  # Suppresses warning C4710
+                                                        /wd4625  # Suppresses warning C4625
+                                                        /wd4526  # Suppresses warning C4626
+                                                        /wd5045  # Suppresses warning C5045 (spectre)
+                                                        /wd4365  # Supresses  warning C4365
                                                        )
 
         # Get list of all dll files in the onnxruntime lib directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,14 @@ else()
         # Link the specific .lib file libraries to LOWWI
         target_link_libraries(${PROJECT_NAME} onnxruntime onnxruntime_providers_shared)
 
+        # Turn off some compile warnings which are windows specific (but not fixable, due to it being an ONNX problem)
+        target_compile_options(${PROJECT_NAME} PRIVATE /wd4820  # Suppresses warning C4820
+                                                       /wd4514  # Suppresses warning C4514
+                                                       /wd4710  # Suppresses warning C4710
+                                                       /wd4626  # Suppresses warning C4625
+                                                       /Qspectre # Enable spectre vulnerability mitigations
+                                                       )
+
         # Get list of all dll files in the onnxruntime lib directory
         file(GLOB onnx_dll_files ${ONNXRUNTIME_ROOTDIR}/lib/*.dll)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/src/lowwi.cpp
                             ${CMAKE_CURRENT_LIST_DIR}/src/lowwi_melspectrogram.cpp
                             ${CMAKE_CURRENT_LIST_DIR}/src/lowwi_embedding.cpp
                             ${CMAKE_CURRENT_LIST_DIR}/src/lowwi_wakeword.cpp)
+target_compile_options(${PROJECT_NAME} PRIVATE "-Wall")
 # Create alias CLFML::Lowi
 add_library(CLFML::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
@@ -143,7 +144,7 @@ if(CLFML_LOWWI_BUILD_EXAMPLE_PROJECTS)
                                   ${CMAKE_CURRENT_LIST_DIR}/example/LOWWI_demo_mic/audio_async/audio_async.cpp)
     
     # Set the example fragments path
-    set(LOWWI_EXAMPLE_FRAGMENTS_PATH $<TARGET_FILE_DIR:${PROJECT_NAME}>/example_fragments)
+    set(LOWWI_EXAMPLE_FRAGMENTS_PATH $<TARGET_FILE_DIR:${PROJECT_NAME}>)
     target_compile_definitions(LOWWI_demo PUBLIC -DCLFML_LOWWI_EXAMPLE_FRAGMENTS="${LOWWI_EXAMPLE_FRAGMENTS_PATH}")
 
     # Link Lowwi demo's with Lowwi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ add_library(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/src/lowwi.cpp
                             ${CMAKE_CURRENT_LIST_DIR}/src/lowwi_embedding.cpp
                             ${CMAKE_CURRENT_LIST_DIR}/src/lowwi_wakeword.cpp)
 target_compile_options(${PROJECT_NAME} PRIVATE "-Wall")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(${PROJECT_NAME} PRIVATE /wd4625  # Suppresses warning C4625
+                                                   /wd4526  # Suppresses warning C4626
+                                                   )
+endif()
+
 # Create alias CLFML::Lowi
 add_library(CLFML::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE "-Wall")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     target_compile_options(${PROJECT_NAME} PRIVATE /wd4625  # Suppresses warning C4625
-                                                   /wd4526  # Suppresses warning C4626
+                                                   /wd4626  # Suppresses warning C4626
                                                    )
 endif()
 
@@ -76,7 +76,7 @@ else()
                                                         /wd4514  # Suppresses warning C4514
                                                         /wd4710  # Suppresses warning C4710
                                                         /wd4625  # Suppresses warning C4625
-                                                        /wd4526  # Suppresses warning C4626
+                                                        /wd4626  # Suppresses warning C4626
                                                         /wd5045  # Suppresses warning C5045 (spectre)
                                                         /wd4365  # Supresses  warning C4365
                                                        )

--- a/src/lowwi.hpp
+++ b/src/lowwi.hpp
@@ -60,6 +60,7 @@ namespace CLFML::LOWWI
      */
     struct Lowwi_word_t
     {
+        uint8_t debug = false;
         std::string phrase = "";
         std::filesystem::path model_path = std::filesystem::path("");
         std::function<void(Lowwi_ctx_t, std::shared_ptr<void>)> cbfunc = nullptr;
@@ -67,7 +68,6 @@ namespace CLFML::LOWWI
         int refractory = 20;
         float threshold = 0.5f;
         float min_activations = 5;
-        uint8_t debug = false;
     };
 
     class Lowwi

--- a/src/lowwi.hpp
+++ b/src/lowwi.hpp
@@ -67,7 +67,7 @@ namespace CLFML::LOWWI
         std::shared_ptr<void> cb_arg = nullptr;
         int refractory = 20;
         float threshold = 0.5f;
-        float min_activations = 5;
+        uint32_t min_activations = 5;
     };
 
     class Lowwi

--- a/src/lowwi_embedding.cpp
+++ b/src/lowwi_embedding.cpp
@@ -82,7 +82,13 @@ namespace CLFML::LOWWI
             const float *emb_out_data = emb_out.GetTensorData<float>();
 
             /* Small gotcha! Reserving before copy saves so much time! */
-            size_t emb_out_count = emb_shape.at(3);
+            int64_t emb_out_count = emb_shape.at(3);
+
+            /* Return early if we got a negative number, which would cause severe memory issues! */
+            if(emb_out_count < 0) {
+                return _embedding_out;
+            }
+
             _embedding_out.reserve(_embedding_out.size() + emb_out_count);
 
             /* Copy the embedding data from output tensor to internal buffer */

--- a/src/lowwi_embedding.cpp
+++ b/src/lowwi_embedding.cpp
@@ -48,7 +48,6 @@ namespace CLFML::LOWWI
         const size_t _embedding_window_size = 76;
         const size_t _embedding_mels_per_frame = 32; // fixed by model
         const size_t _embedding_step_size = 8;       // 80 ms
-        const size_t _embedding_frame_size = 1280 * 4;
 
         /* Calculate the amount of mel_frames to process */
         size_t mel_frames = _samples_to_process.size() / _embedding_mels_per_frame;

--- a/src/lowwi_embedding.hpp
+++ b/src/lowwi_embedding.hpp
@@ -32,6 +32,16 @@ namespace CLFML::LOWWI
     {
     public:
         /**
+          * @brief Prevent this class from being used with copy constructor
+          */
+         Embedding(const Embedding&) = delete;
+         
+        /**
+          * @brief Prevent this class from being used with assignment constructor
+          */
+         Embedding& operator=(const Embedding&) = delete;
+
+        /**
          * @param env Reference to Onnx environment which the model will run in
          * @param session_options Reference to Onnx options which configure the session for this model
          */

--- a/src/lowwi_melspectrogram.cpp
+++ b/src/lowwi_melspectrogram.cpp
@@ -96,7 +96,8 @@ namespace CLFML::LOWWI
 
             /* Scale/normalize the melspectrogram to range required for Google embedding model
              * See the paper for this model here: https://arxiv.org/abs/2002.01322
-            /* Now values will be in range 1.0 to 6.0 dB instead of -10.0 to 40.0 dB */
+             * Now values will be in range 1.0 to 6.0 dB instead of -10.0 to 40.0 dB 
+             */
             std::transform(mel_data, mel_data + mel_count, std::back_inserter(_melspectrogram_out),
                            [](float val)
                            { return (val / 10.0f) + 2.0f; });

--- a/src/lowwi_melspectrogram.hpp
+++ b/src/lowwi_melspectrogram.hpp
@@ -31,6 +31,15 @@ namespace CLFML::LOWWI
     class Melspectrogram
     {
     public:
+        /**
+          * @brief Prevent this class from being used with copy constructor
+          */
+         Melspectrogram(const Melspectrogram&) = delete;
+         
+        /**
+          * @brief Prevent this class from being used with assignment constructor
+          */
+         Melspectrogram& operator=(const Melspectrogram&) = delete;
 
         /**
          * @param env Reference to Onnx environment which the model will run in

--- a/src/lowwi_wakeword.cpp
+++ b/src/lowwi_wakeword.cpp
@@ -27,7 +27,7 @@ namespace CLFML::LOWWI
 
     WakeWord::WakeWord(Ort::Env &env, Ort::SessionOptions &session_options,
                        const std::filesystem::path model_path, const float threshold,
-                       const float min_activations, const int refractory, const uint8_t debug)
+                       const uint32_t min_activations, const int refractory, const uint8_t debug)
         : _env(env),
           _session_options(session_options),
           _session(nullptr), // Initialize session as nullptr (it will be assigned later)
@@ -63,7 +63,7 @@ namespace CLFML::LOWWI
         std::copy(features.begin(), features.end(), std::back_inserter(_samples_to_process));
 
         /* Used for scoring the wakeword probability/confidence */
-        int activation = 0;
+        uint32_t activation = 0;
         int num_of_triggers = 0;
         int sum_probability = 0;
 

--- a/src/lowwi_wakeword.hpp
+++ b/src/lowwi_wakeword.hpp
@@ -76,7 +76,7 @@ namespace CLFML::LOWWI
 
         std::vector<float> _samples_to_process;
         
-        const uint8_t _debug = false;
+        uint8_t _debug = false;
         const std::filesystem::path _model_path;
         const float _threshold;
         const float _min_activations;

--- a/src/lowwi_wakeword.hpp
+++ b/src/lowwi_wakeword.hpp
@@ -64,7 +64,7 @@ namespace CLFML::LOWWI
                  Ort::SessionOptions &session_options, 
                  const std::filesystem::path model_path, 
                  const float threshold, 
-                 const float min_activations, 
+                 const uint32_t min_activations, 
                  const int refractory, 
                  const uint8_t debug);
 
@@ -89,7 +89,7 @@ namespace CLFML::LOWWI
         uint8_t _debug = false;
         const std::filesystem::path _model_path;
         const float _threshold;
-        const float _min_activations;
+        const uint32_t _min_activations;
         const int _refractory;
     };
 }

--- a/src/lowwi_wakeword.hpp
+++ b/src/lowwi_wakeword.hpp
@@ -30,13 +30,23 @@ namespace CLFML::LOWWI
 {
     /* Wakeword result struct returned by the detect function */
     struct wakeword_result {
-        float confidence;
         uint8_t detected;
+        float confidence;
     };
 
     class WakeWord
     {
     public:
+        /**
+          * @brief Prevent this class from being used with copy constructor
+          */
+         WakeWord(const WakeWord&) = delete;
+         
+        /**
+          * @brief Prevent this class from being used with assignment constructor
+          */
+         WakeWord& operator=(const WakeWord&) = delete;
+
         /**
          * @brief Create new wakeword
          * @param env Onnx environment to run the model in


### PR DESCRIPTION
# Goal

This PR fixes:
- The compiler warnings in GCC about the initialization order of class variables in the WakeWord class being initialized improperly #4 .
- The problem of a wrong path for the example fragments I stumbled upon when running the fragment demo. 
- The problem of not properly typed comment block #2 
- Removed unused variable #3 
- And last but not least it added -Wall to cmake compilation to get more compiler warnings visible in early development 